### PR TITLE
README: update Neovim section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,28 +23,11 @@ And just runs a simple type check
 
 If you can get this working with your editor, please open an issue/pr to add it here!
 
-### NeoVim 0.5
+### Neovim 0.7
 
 Install the [lspconfig plugin](https://github.com/neovim/nvim-lspconfig) and put the following in your `init.vim` or `init.lua`
 ```lua
 local lspconfig = require("lspconfig")
-local configs = require("lspconfig/configs") -- Make sure this is a slash (as theres some metamagic happening behind the scenes)
-if not lspconfig.teal then
-   configs.teal = {
-      default_config = {
-         cmd = {
-            "teal-language-server",
-            -- "logging=on", use this to enable logging in /tmp/teal-language-server.log
-         },
-         filetypes = {
-            "teal",
-            -- "lua", -- Also works for lua, but you may get type errors that cannot be resolved within lua itself
-         },
-         root_dir = lspconfig.util.root_pattern("tlconfig.lua", ".git"),
-         settings = {},
-      },
-   }
-end
-lspconfig.teal.setup{}
 
+lspconfig.teal_ls.setup {}
 ```


### PR DESCRIPTION
A default config for teal-language-server was added to lspconfig here: https://github.com/neovim/nvim-lspconfig/pull/1732