### PR TITLE
Make installable via LuaRocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build
         run: scripts/setup_local_luarocks.sh
 
+      - name: Run Tests
+        run: scripts/run_tests.sh
+
       - name: Lint
         run: scripts/lint_teal.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@v4
+        with:
+          luarocksVersion: "3.10.0"
 
       - name: Build
         run: scripts/setup_local_luarocks.sh

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Navigate to the root of the repo
+cd "$(dirname "$0")/.."
+
+# Set the local LuaRocks path
+LUAROCKS_TREE="$(pwd)/luarocks_tree"
+
+# Run unit tests
+echo "Run LuaRocks tests:"
+luarocks test --tree="$LUAROCKS_TREE"

--- a/scripts/setup_local_luarocks.sh
+++ b/scripts/setup_local_luarocks.sh
@@ -4,10 +4,13 @@ set -e
 # Navigate to the root of the repo
 cd "$(dirname "$0")/.."
 
-luarocks init --tree=./luarocks_tree
-
 # Set the local LuaRocks path
 LUAROCKS_TREE="$(pwd)/luarocks_tree"
+
+# setup local LuaRocks
+luarocks init --tree="$LUAROCKS_TREE"
+PATH="$LUAROCKS_TREE/bin":"$PATH"
+export PATH
 
 # Install project dependencies from the rockspec
 echo "Installing project dependencies..."

--- a/teal-language-server-0.0.5-1.rockspec
+++ b/teal-language-server-0.0.5-1.rockspec
@@ -23,8 +23,8 @@ dependencies = {
    "inspect",
    "luv",
    "lusc_luv >= 4.0",
-   "ltreesitter",
-   "tree-sitter-cli",
+   "ltreesitter-ts==0.0.1",
+   "tree-sitter-cli==0.24.4",
    "tree-sitter-teal",
 }
 
@@ -47,6 +47,7 @@ build = {
       ["teal_language_server.env_updater"] = "gen/teal_language_server/env_updater.lua",
       ["teal_language_server.lsp"] = "gen/teal_language_server/lsp.lua",
       ["teal_language_server.lsp_events_manager"] = "gen/teal_language_server/lsp_events_manager.lua",
+      ["teal_language_server.lsp_formatter"] = "gen/teal_language_server/lsp_formatter.lua",
       ["teal_language_server.lsp_reader_writer"] = "gen/teal_language_server/lsp_reader_writer.lua",
       ["teal_language_server.main"] = "gen/teal_language_server/main.lua",
       ["teal_language_server.misc_handlers"] = "gen/teal_language_server/misc_handlers.lua",

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -24,9 +24,6 @@ dependencies = {
    "luv",
    "lusc_luv >= 4.0",
    "ltreesitter-ts==0.0.1",
-   -- install script works locally for me and installs via LuaRocks via hererocks without this line.
-   -- trying to work with the CI/CD pipeline, hopefully this is all that's needed
-   "luarocks-build-tree-sitter-cli==0.0.2", 
    "tree-sitter-cli==0.24.4",
    "tree-sitter-teal",
 }

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -24,6 +24,9 @@ dependencies = {
    "luv",
    "lusc_luv >= 4.0",
    "ltreesitter-ts==0.0.1",
+   -- install script works locally for me and installs via LuaRocks via hererocks without this line.
+   -- trying to work with the CI/CD pipeline, hopefully this is all that's needed
+   "luarocks-build-tree-sitter-cli==0.0.2", 
    "tree-sitter-cli==0.24.4",
    "tree-sitter-teal",
 }

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 rockspec_format = "3.0"
 
 package = "teal-language-server"
-version = "0.0.5-1"
+version = "0.1.0-1"
 
 source = {
    url = "git+https://github.com/teal-language/teal-language-server.git",


### PR DESCRIPTION
With this PR in place `teal-language-server` can now be installed on systems with LuaRocks 3.10.0+ and Node installed!

## Changes
- Switched to [`ltreesitter-ts`](https://github.com/FourierTransformer/ltreesitter-ts) which bundles the tree-sitter library as well as `ltreesitter`. 
  - I put in an issue in the ltreesitter repo about potentially including the library as part of the bindings
- Updated rockspec for the eventual new version
- Added running tests as part of GHA
- Updated LuaRocks to 3.10.0 in GHA (used to be 3.8.0)

## Current Issues
- Need to see if we can drop Node as a requirement. If the tree-sitter CLI can generate a grammar from the JSON file without Node, it should be possible.
- It will only install on LuaRocks 3.10.0 and above
  - This is due to the changes that happened to custom build systems in 3.10.0. When I was working on tree-sitter-cli, I was initially targeting 3.8.0, but ran into issues with newer versions of LuaRocks. I'm sure there's some way to get it all working.

helps #26 