### PR TITLE
Specify and pin dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@v4
         with:
-          luarocksVersion: "3.10.0"
+          luarocksVersion: "3.11.1"
 
       - name: Build
         run: scripts/setup_local_luarocks.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install LuaRocks
         uses: leafo/gh-actions-luarocks@v4
         with:
-          luarocksVersion: "3.11.1"
+          luarocksVersion: "3.10.0"
 
       - name: Build
         run: scripts/setup_local_luarocks.sh

--- a/luarocks.lock
+++ b/luarocks.lock
@@ -1,0 +1,22 @@
+return {
+   build_dependencies = {
+      luafilesystem = "1.8.0-1",
+      ["luarocks-build-tree-sitter-cli"] = "0.0.2-1",
+      ["luarocks-build-treesitter-parser"] = "6.0.0-1"
+   },
+   dependencies = {
+      argparse = "0.7.1-1",
+      compat53 = "0.14.4-1",
+      inspect = "3.1.3-0",
+      ["ltreesitter-ts"] = "0.0.1-1",
+      ["lua-cjson"] = "2.1.0.10-1",
+      luafilesystem = "1.8.0-1",
+      ["luarocks-build-tree-sitter-cli"] = "0.0.2-1",
+      ["luarocks-build-treesitter-parser"] = "6.0.0-1",
+      lusc_luv = "4.0.1-1",
+      luv = "1.50.0-1",
+      tl = "0.24.4-1",
+      ["tree-sitter-cli"] = "0.24.4-1",
+      ["tree-sitter-teal"] = "0.0.33-1"
+   },
+}

--- a/luarocks.lock
+++ b/luarocks.lock
@@ -11,12 +11,10 @@ return {
       ["ltreesitter-ts"] = "0.0.1-1",
       ["lua-cjson"] = "2.1.0.10-1",
       luafilesystem = "1.8.0-1",
-      ["luarocks-build-tree-sitter-cli"] = "0.0.2-1",
-      ["luarocks-build-treesitter-parser"] = "6.0.0-1",
       lusc_luv = "4.0.1-1",
       luv = "1.50.0-1",
       tl = "0.24.4-1",
-      ["tree-sitter-cli"] = "0.24.4-1",
+      ["tree-sitter-cli"] = "0.24.4-2",
       ["tree-sitter-teal"] = "0.0.33-1"
    },
 }

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -15,6 +15,10 @@ description = {
    license = "MIT"
 }
 
+build_dependencies = {
+   "luarocks-build-treesitter-parser >= 6.0.0", -- can be removed when tree-sitter-teal specifies this version >= 6
+}
+
 dependencies = {
    "luafilesystem",
    "tl == 0.24.4",
@@ -25,7 +29,6 @@ dependencies = {
    "lusc_luv >= 4.0",
    "ltreesitter-ts == 0.0.1", -- can be removed when ltreesitter updates
    "tree-sitter-cli == 0.24.4",
-   "luarocks-build-treesitter-parser >= 6.0.0", -- can be removed when tree-sitter-teal specifies this version >= 6
    "tree-sitter-teal == 0.0.33",
 }
 

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -17,15 +17,16 @@ description = {
 
 dependencies = {
    "luafilesystem",
-   "tl",
+   "tl == 0.24.4",
    "lua-cjson",
    "argparse",
    "inspect",
-   "luv",
+   "luv ~> 1",
    "lusc_luv >= 4.0",
-   "ltreesitter-ts==0.0.1",
-   "tree-sitter-cli==0.24.4",
-   "tree-sitter-teal",
+   "ltreesitter-ts == 0.0.1", -- can be removed when ltreesitter updates
+   "tree-sitter-cli == 0.24.4",
+   "luarocks-build-treesitter-parser >= 6.0.0", -- can be removed when tree-sitter-teal specifies this version >= 6
+   "tree-sitter-teal == 0.0.33",
 }
 
 test_dependencies = { "busted~>2" }

--- a/teal-language-server-0.1.0-1.rockspec
+++ b/teal-language-server-0.1.0-1.rockspec
@@ -5,7 +5,7 @@ version = "0.1.0-1"
 
 source = {
    url = "git+https://github.com/teal-language/teal-language-server.git",
-   branch = "main"
+   tag = "0.1.0"
 }
 
 description = {


### PR DESCRIPTION
- Created a `luarocks.lock` file with the specific versions that are known to work. Hopefully this helps make installs a bit more consistent.
- Specified a tag in the rockspec file, so it will always try and use the tagged version from git while doing installs.

closes #26 