### PR TITLE
Build binaries for Mac and Windows

### DIFF
--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -44,7 +44,9 @@ jobs:
       # waiting on new luarocks release for fix, so we don't need node
       # - uses: actions/setup-node@v4
       - name: install tree-sitter-cli
-        run: npm install -g tree-sitter-cli@0.24.4
+        run: | 
+          npm install -g tree-sitter-cli@0.24.4
+          npm bin -g | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter --version
     

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -60,7 +60,10 @@ jobs:
         run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
       
       - name: Build teal-language-server
-        run: luarocks install teal-language-server
+        run: | 
+          luarocks init --tree=./luarocks
+          set "LUAROCKS_TREE=%~dp0\..\luarocks"
+          luarocks install teal-language-server --tree=!LUAROCKS_TREE!
       
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -1,0 +1,34 @@
+name: Create Binary
+
+on: [push, pull_request]
+
+jobs:
+  lua:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macos, macos-arm64, windows]
+        include:
+        - os: linux
+          runner: ubuntu-22.04
+        - os: macos
+          runner: macos-13
+        - os: macos-arm64
+          runner: macos-14
+        - os: windows
+          runner: windows-2022
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v4
+      - name: Build teal-language-server (${{ matrix.os }})
+        shell: bash
+        run: |
+          cd scripts
+          ./create_binary.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tls-${{matrix.os}}
+          path: "./scripts/tls"
+

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -10,12 +10,12 @@ jobs:
         #os: [linux, macos, macos-arm64, windows]
         os: [windows]
         include:
-        - os: linux
-          runner: ubuntu-22.04
-        - os: macos
-          runner: macos-13
-        - os: macos-arm64
-          runner: macos-14
+        # - os: linux
+        #   runner: ubuntu-22.04
+        # - os: macos
+        #   runner: macos-13
+        # - os: macos-arm64
+        #   runner: macos-14
         - os: windows
           runner: windows-2022
     name: ${{ matrix.os }}

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -37,20 +37,15 @@ jobs:
   windows:
     strategy:
       fail-fast: false
-      matrix:
-        target: [mingw,vs]
     runs-on: windows-2022
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
-      - name: Install Lua (${{ matrix.lua }})
-        run: |
-          pip install hererocks
-          hererocks lua_install -r "@v3.11.1" -l "@v5.4.7" --target ${{ matrix.target }}
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: leafo/gh-actions-lua@v11
+      - uses: leafo/gh-actions-luarocks@v5
       - name: Build teal-language-server
-        run: |
-          .\lua_install\bin\activate
-          luarocks install teal-language-server
+        run: luarocks install teal-language-server
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -49,8 +49,10 @@ jobs:
       
       # waiting on new luarocks release for fix
       - name: install tree-sitter-cli
-        run: npm install -g tree-sitter-cli@0.24.4
-      - name: luarocks workaround for tree-sitte
+        run: cargo install tree-sitter-cli --version 0.24.4
+      - name: verify tree-sitter-cli is installed on path
+        run: tree-sitter-cli --version
+      - name: luarocks workaround for tree-sitter
         run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
       
       - name: Build teal-language-server

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -3,34 +3,57 @@ name: Create Binary
 on: [push, pull_request]
 
 jobs:
-  lua:
+  # lua:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       #os: [linux, macos, macos-arm64, windows]
+  #       os: [windows]
+  #       include:
+  #       # - os: linux
+  #       #   runner: ubuntu-22.04
+  #       # - os: macos
+  #       #   runner: macos-13
+  #       # - os: macos-arm64
+  #       #   runner: macos-14
+  #       - os: windows
+  #         runner: windows-2022
+  #   name: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.runner }}
+  #   steps:
+  #     # Checks-out the repository under $GITHUB_WORKSPACE.
+  #     - uses: actions/checkout@v4
+  #     - name: Build teal-language-server (${{ matrix.os }})
+  #       shell: bash
+  #       run: |
+  #         cd scripts
+  #         ./create_binary.sh
+  #     - uses: actions/upload-artifact@v4
+  #       if: always()
+  #       with:
+  #         name: tls-${{matrix.os}}
+  #         path: "./scripts/tls"
+  
+  windows:
     strategy:
       fail-fast: false
       matrix:
-        #os: [linux, macos, macos-arm64, windows]
-        os: [windows]
-        include:
-        # - os: linux
-        #   runner: ubuntu-22.04
-        # - os: macos
-        #   runner: macos-13
-        # - os: macos-arm64
-        #   runner: macos-14
-        - os: windows
-          runner: windows-2022
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.runner }}
+        target: [mingw,vs]
+    runs-on: windows-2022
     steps:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
-      - name: Build teal-language-server (${{ matrix.os }})
-        shell: bash
+      - name: Install Lua (${{ matrix.lua }})
         run: |
-          cd scripts
-          ./create_binary.sh
+          pip install hererocks
+          hererocks lua_install -r "@v3.11.1" --"@5.4.7" --target ${{ matrix.target }}
+      - name: Build teal-language-server
+        run: |
+          .\lua_install\bin\activate
+          luarocks install teal-language-server
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tls-${{matrix.os}}
-          path: "./scripts/tls"
+          name: tls-windows-${{ matrix.target }}
+          path: "lua_install"
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           npm install -g tree-sitter-cli@0.24.4
           npm list -g
-          C:\npm\prefix\bin >> $GITHUB_PATH 
+          echo "C:\npm\prefix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
       - name: luarocks workaround for tree-sitter

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -39,6 +39,17 @@ jobs:
       fail-fast: false
     runs-on: windows-2022
     steps:
+
+
+      # waiting on new luarocks release for fix, so we don't need node
+      - uses: actions/setup-node@v4
+      - name: install tree-sitter-cli
+        run: |
+          npm install -g tree-sitter-cli@0.24.4
+          npm list -g
+      - name: verify tree-sitter-cli is installed on path
+        run: tree-sitter-cli --version
+    
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
@@ -46,16 +57,7 @@ jobs:
       - uses: luarocks/gh-actions-luarocks@v5
         # with:
         #   luaRocksVersion: "3.11.1"
-      
-      # waiting on new luarocks release for fix
-      - name: install tree-sitter-cli
-        run: |
-          npm install -g tree-sitter-cli@0.24.4
-          npm list -g
-          npm config get prefix
-          npm config get prefix | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: verify tree-sitter-cli is installed on path
-        run: tree-sitter-cli --version
+
       - name: luarocks workaround for tree-sitter
         run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
       

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,12 +42,11 @@ jobs:
 
 
       # waiting on new luarocks release for fix, so we don't need node
-      - uses: actions/setup-node@v4
+      # - uses: actions/setup-node@v4
       - name: install tree-sitter-cli
-        run: |
-          npm install tree-sitter-cli@0.24.4
+        run: npm install -g tree-sitter-cli@0.24.4
       - name: verify tree-sitter-cli is installed on path
-        run: tree-sitter-cli --version
+        run: tree-sitter --version
     
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -52,7 +52,8 @@ jobs:
         run: |
           npm install -g tree-sitter-cli@0.24.4
           npm list -g
-          echo "C:\npm\prefix\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          npm config get prefix
+          npm config get prefix | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
       - name: luarocks workaround for tree-sitter

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,6 +42,8 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion: 2022
       - name: Install Lua
         run: |
           pip install hererocks

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -60,7 +60,8 @@ jobs:
       
       - name: Build teal-language-server
         run: | 
-          luarocks install teal-language-server
+          luarocks init --tree=.\luarocks
+          luarocks install teal-language-server --tree=.\luarocks
       
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -3,46 +3,40 @@ name: Create Binary
 on: [push, pull_request]
 
 jobs:
-  # lua:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       #os: [linux, macos, macos-arm64, windows]
-  #       os: [windows]
-  #       include:
-  #       # - os: linux
-  #       #   runner: ubuntu-22.04
-  #       # - os: macos
-  #       #   runner: macos-13
-  #       # - os: macos-arm64
-  #       #   runner: macos-14
-  #       - os: windows
-  #         runner: windows-2022
-  #   name: ${{ matrix.os }}
-  #   runs-on: ${{ matrix.runner }}
-  #   steps:
-  #     # Checks-out the repository under $GITHUB_WORKSPACE.
-  #     - uses: actions/checkout@v4
-  #     - name: Build teal-language-server (${{ matrix.os }})
-  #       shell: bash
-  #       run: |
-  #         cd scripts
-  #         ./create_binary.sh
-  #     - uses: actions/upload-artifact@v4
-  #       if: always()
-  #       with:
-  #         name: tls-${{matrix.os}}
-  #         path: "./scripts/tls"
+  lua:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macos, macos-arm64]
+        include:
+        - os: linux
+          runner: ubuntu-22.04
+        - os: macos
+          runner: macos-13
+        - os: macos-arm64
+          runner: macos-14
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v4
+      - name: Build teal-language-server (${{ matrix.os }})
+        shell: bash
+        run: |
+          cd scripts
+          ./create_binary.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tls-${{matrix.os}}
+          path: "./scripts/tls"
   
   windows:
     strategy:
       fail-fast: false
     runs-on: windows-2022
     steps:
-
-
-      # waiting on new luarocks release for fix, so we don't need node
-      # - uses: actions/setup-node@v4
+      # waiting on new luarocks release for fix, so we don't need to install via choco
       - name: install tree-sitter-cli
         run: | 
           choco install tree-sitter --version 0.24.4

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,8 +42,6 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          vsversion: 2015
       - name: Install Lua
         run: |
           pip install hererocks
@@ -51,6 +49,7 @@ jobs:
       - name: Build teal-language-server
         run: |
           .\lua_install\bin\activate
+          set VS=17
           luarocks install teal-language-server
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -45,8 +45,7 @@ jobs:
       - uses: actions/setup-node@v4
       - name: install tree-sitter-cli
         run: |
-          npm install -g tree-sitter-cli@0.24.4
-          npm list -g
+          npm install tree-sitter-cli@0.24.4
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
     

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build teal-language-server
         run: | 
           luarocks init --tree=.\luarocks
-          luarocks install teal-language-server --tree=.\luarocks
+          luarocks make --tree=.\luarocks
 
       - name: Run create_binary script
         shell: bash

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -r "@v3.11.1" --"@v5.4.7" --target ${{ matrix.target }}
+          hererocks lua_install -r "@v3.11.1" -l "@v5.4.7" --target ${{ matrix.target }}
       - name: Build teal-language-server
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -46,11 +46,15 @@ jobs:
       - uses: luarocks/gh-actions-luarocks@v5
         with:
           luaRocksVersion: "3.11.1"
+      - name: install tree-sitter-cli
+        run: npm install -g tree-sitter-cli@0.24.4
+      - name: luarocks workaround for tree-sitter # waiting on new luarocks release for fix
+        run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
       - name: Build teal-language-server
         run: ./scripts/setup_local_luarocks.bat
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tls-windows-${{ matrix.target }}
-          path: "./luarocks"
+          name: debug
+          path: "."
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           npm install -g tree-sitter-cli@0.24.4
           npm list -g
-          Add-Content $env:GITHUB_PATH %USERPROFILE%\AppData\Roaming\npm\node_modules
+          Add-Content $env:GITHUB_PATH C:\npm\prefix\bin
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
       - name: luarocks workaround for tree-sitter

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -54,17 +54,13 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: leafo/gh-actions-lua@v11
       - uses: luarocks/gh-actions-luarocks@v5
-        # with:
-        #   luaRocksVersion: "3.11.1"
 
       - name: luarocks workaround for tree-sitter
         run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
       
       - name: Build teal-language-server
         run: | 
-          luarocks init --tree=./luarocks
-          set "LUAROCKS_TREE=%~dp0\..\luarocks"
-          luarocks install teal-language-server --tree=!LUAROCKS_TREE!
+          luarocks install teal-language-server
       
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
         with:
-          vsversion: 2022
+          vsversion: 2015
       - name: Install Lua
         run: |
           pip install hererocks

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
-          hererocks lua_install -r "@v3.11.1" --"@5.4.7" --target ${{ matrix.target }}
+          hererocks lua_install -r "@v3.11.1" --"@v5.4.7" --target ${{ matrix.target }}
       - name: Build teal-language-server
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -43,12 +43,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: leafo/gh-actions-lua@v11
-      - uses: leafo/gh-actions-luarocks@v5
+      - uses: luarocks/gh-actions-luarocks@v5
+        with:
+          luaRocksVersion: "3.11.1"
       - name: Build teal-language-server
-        run: luarocks install teal-language-server
+        run: ./scripts/setup_local_luarocks.bat
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tls-windows-${{ matrix.target }}
-          path: "lua_install"
+          path: "./luarocks"
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -62,12 +62,13 @@ jobs:
         run: | 
           luarocks init --tree=.\luarocks
           luarocks install teal-language-server --tree=.\luarocks
+
+      - name: Run create_binary script
+        shell: bash
+        run: ./scripts/create_windows_binary.sh
       
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: debug
-          path: "."
-          include-hidden-files: true
-
-
+          name: tls-windows
+          path: "teal-language-server"

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -45,8 +45,7 @@ jobs:
       # - uses: actions/setup-node@v4
       - name: install tree-sitter-cli
         run: | 
-          npm install -g tree-sitter-cli@0.24.4
-          npm bin -g | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          choco install tree-sitter --version 0.24.4
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter --version
     

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           npm install -g tree-sitter-cli@0.24.4
           npm list -g
-          Add-Content $env:GITHUB_PATH C:\npm\prefix\bin
+          C:\npm\prefix\bin >> $GITHUB_PATH 
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
       - name: luarocks workaround for tree-sitter

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -3,18 +3,16 @@ name: Create Binary
 on: [push, pull_request]
 
 jobs:
-  lua:
+  macos:
     strategy:
       fail-fast: false
       matrix:
-        os: [linux, macos, macos-arm64]
+        os: [macos, macos-arm64]
         include:
-        - os: linux
-          runner: ubuntu-22.04
         - os: macos
           runner: macos-13
         - os: macos-arm64
-          runner: macos-14
+          runner: macos-latest
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -7,7 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [linux, macos, macos-arm64, windows]
+        #os: [linux, macos, macos-arm64, windows]
+        os: [windows]
         include:
         - os: linux
           runner: ubuntu-22.04

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -1,6 +1,10 @@
-name: Create Binary
+name: Create Binaries
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - '**'
+  pull_request:
 
 jobs:
   macos:

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,20 +42,18 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: leafo/gh-actions-lua@v11
-      - uses: luarocks/gh-actions-luarocks@v5
-        with:
-          luaRocksVersion: "3.11.1"
-      - name: install tree-sitter-cli
-        run: npm install -g tree-sitter-cli@0.24.4
-      - name: luarocks workaround for tree-sitter # waiting on new luarocks release for fix
-        run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
+      - name: Install Lua
+        run: |
+          pip install hererocks
+          hererocks lua_install -r@28f9d98 -l "@v5.4.7" --target vs
       - name: Build teal-language-server
-        run: ./scripts/setup_local_luarocks.bat
+        run: |
+          .\lua_install\bin\activate
+          luarocks install teal-language-server
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: debug
-          path: "."
+          path: "lua_install"
           include-hidden-files: true
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,6 +42,7 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
+      - uses: microsoft/setup-msbuild@v2
       - name: Install Lua
         run: |
           pip install hererocks
@@ -49,7 +50,6 @@ jobs:
       - name: Build teal-language-server
         run: |
           .\lua_install\bin\activate
-          set VS=17
           luarocks install teal-language-server
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -57,4 +57,5 @@ jobs:
         with:
           name: debug
           path: "."
+          include-hidden-files: true
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,18 +42,25 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
-      - name: Install Lua
-        run: |
-          pip install hererocks
-          hererocks lua_install -r@28f9d98 -j "@v2.1"
+      - uses: leafo/gh-actions-lua@v11
+      - uses: luarocks/gh-actions-luarocks@v5
+        # with:
+        #   luaRocksVersion: "3.11.1"
+      
+      # waiting on new luarocks release for fix
+      - name: install tree-sitter-cli
+        run: npm install -g tree-sitter-cli@0.24.4
+      - name: luarocks workaround for tree-sitte
+        run: luarocks config --lua-version 5.4 rocks_provided.tree-sitter-cli 0.24.4-2
+      
       - name: Build teal-language-server
-        run: |
-          .\lua_install\bin\activate
-          luarocks install teal-language-server
+        run: luarocks install teal-language-server
+      
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: debug
-          path: "lua_install"
+          path: "."
           include-hidden-files: true
+
 

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -42,11 +42,10 @@ jobs:
       # Checks-out the repository under $GITHUB_WORKSPACE.
       - uses: actions/checkout@v4
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: microsoft/setup-msbuild@v2
       - name: Install Lua
         run: |
           pip install hererocks
-          hererocks lua_install -r@28f9d98 -l "@v5.4.7" --target vs
+          hererocks lua_install -r@28f9d98 -j "@v2.1"
       - name: Build teal-language-server
         run: |
           .\lua_install\bin\activate

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -49,7 +49,10 @@ jobs:
       
       # waiting on new luarocks release for fix
       - name: install tree-sitter-cli
-        run: cargo install tree-sitter-cli --version 0.24.4
+        run: |
+          npm install -g tree-sitter-cli@0.24.4
+          npm list -g
+          Add-Content $env:GITHUB_PATH %USERPROFILE%\AppData\Roaming\npm\node_modules
       - name: verify tree-sitter-cli is installed on path
         run: tree-sitter-cli --version
       - name: luarocks workaround for tree-sitter

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -29,6 +29,7 @@ jobs:
           cd scripts
           ./create_binary.sh
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: tls-${{matrix.os}}
           path: "./scripts/tls"

--- a/.github/workflows/create-binaries.yml
+++ b/.github/workflows/create-binaries.yml
@@ -21,13 +21,12 @@ jobs:
       - name: Build teal-language-server (${{ matrix.os }})
         shell: bash
         run: |
-          cd scripts
-          ./create_binary.sh
+          ./scripts/create_binary.sh
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tls-${{matrix.os}}
-          path: "./scripts/tls"
+          path: "./tls"
   
   windows:
     strategy:

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -11,7 +11,7 @@ source tls/bin/activate
 luarocks install teal-language-server
 
 # TODO: see if we can just make this a build dependency?
-luarocks remove tree-sitter-cli
+luarocks remove --force tree-sitter-cli
 
 rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
 rm -f ./tls/bin/json2lua ./tls/bin/lua2json

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -7,13 +7,8 @@ set -e
 pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
-if [[ "$OSTYPE" == "msys" ]]; then
-./tls/bin/luarocks.bat install teal-language-server
-
-else
-export PATH=./tls/bin:$PATH
+source tls/bin/activate
 luarocks install teal-language-server
-fi
 
 rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
 rm -f ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -8,7 +8,7 @@ pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 if [[ "$OSTYPE" == "msys" ]]; then
-source tls/bin/activate.bat
+./tls/bin/activate
 else
 source tls/bin/activate
 fi

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -11,7 +11,7 @@ if [[ "$OSTYPE" == "msys" ]]; then
 ./tls/bin/luarocks.bat install teal-language-server
 
 else
-source tls/bin/activate
+export PATH=./tls/bin:$PATH
 luarocks install teal-language-server
 fi
 

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -8,9 +8,7 @@ pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 if [[ "$OSTYPE" == "msys" ]]; then
-ls ./tls/bin
-./tls/bin/activate.bat
-luarocks.bat install teal-language-server
+./tls/bin/luarocks.bat install teal-language-server
 
 else
 source tls/bin/activate

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -10,11 +10,13 @@ hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 if [[ "$OSTYPE" == "msys" ]]; then
 ls ./tls/bin
 ./tls/bin/activate.bat
+luarocks.bat install teal-language-server
+
 else
 source tls/bin/activate
+luarocks install teal-language-server
 fi
 
-luarocks install teal-language-server
 rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
 rm -f ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
 rm -f ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -7,11 +7,16 @@ set -e
 pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
+if [[ "$OSTYPE" == "msys" ]]; then
+source tls/bin/activate.bat
+else
 source tls/bin/activate
+fi
+
 luarocks install teal-language-server
-#rm ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
-#rm ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
-#rm ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
+rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
+rm -f ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
+rm -f ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
 
 #tls_dir="$(pwd)/tls/"
 #sed -i '' -e '2i\

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -8,10 +8,8 @@ pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 if [[ "$OSTYPE" == "msys" ]]; then
-ls .
-ls ./tls
 ls ./tls/bin
-./tls/bin/activate
+./tls/bin/activate.bat
 else
 source tls/bin/activate
 fi

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -4,11 +4,11 @@
 
 set -e
 
-pip install hererocks
+pip3 install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 source tls/bin/activate
-luarocks install teal-language-server
+luarocks make
 
 # TODO: see if we can just make this a build dependency?
 luarocks remove --force tree-sitter-cli
@@ -16,10 +16,11 @@ luarocks remove --force tree-sitter-cli
 rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
 rm -f ./tls/bin/json2lua ./tls/bin/lua2json
 rm -f ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
+rm -rf ./tls/include
 
-#tls_dir="$(pwd)/tls/"
-#sed -i '' -e '2i\
-#cd "$(dirname "$0")"' ./tls/bin/teal-language-server
-#sed -i '' -e "s*$tls_dir*../*g" ./tls/bin/teal-language-server
+tls_dir="$(pwd)/tls/"
+sed -i '' -e '2i\
+cd "$(dirname "$0")"' ./tls/bin/teal-language-server
+sed -i '' -e "s*$tls_dir*../*g" ./tls/bin/teal-language-server
 
 teal-language-server --help

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -10,8 +10,11 @@ hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 source tls/bin/activate
 luarocks install teal-language-server
 
+# TODO: see if we can just make this a build dependency?
+luarocks remove tree-sitter-cli
+
 rm -f ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
-rm -f ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
+rm -f ./tls/bin/json2lua ./tls/bin/lua2json
 rm -f ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
 
 #tls_dir="$(pwd)/tls/"

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -8,6 +8,9 @@ pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 if [[ "$OSTYPE" == "msys" ]]; then
+ls .
+ls ./tls
+ls ./tls/bin
 ./tls/bin/activate
 else
 source tls/bin/activate

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -4,18 +4,18 @@
 
 set -e
 
-python3 -m pip install hererocks
+pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 source tls/bin/activate
 luarocks install teal-language-server
-rm ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
-rm ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
-rm ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
+#rm ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
+#rm ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
+#rm ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
 
-tls_dir="$(pwd)/tls/"
-sed -i '' -e '2i\
-cd "$(dirname "$0")"' ./tls/bin/teal-language-server
-sed -i '' -e "s*$tls_dir*../*g" ./tls/bin/teal-language-server
+#tls_dir="$(pwd)/tls/"
+#sed -i '' -e '2i\
+#cd "$(dirname "$0")"' ./tls/bin/teal-language-server
+#sed -i '' -e "s*$tls_dir*../*g" ./tls/bin/teal-language-server
 
 teal-language-server --help

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
-# yeah, this is kinda hacky and abusing hererocks, but it works!
+# yeah, this is a bit of a hack by utilizing hererocks and reconfigring it to be portable but it works!
 
 set -e
 
-pip3 install hererocks
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install hererocks
+
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 source tls/bin/activate

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# yeah, this is kinda hacky and abusing hererocks, but it works!
+
+set -e
+
+# python3 -m pip install hererocks
+hererocks -l "@v5.4.7" -r "@v3.11.1" tls
+
+source tls/bin/activate
+luarocks install teal-language-server
+rm ./tls/bin/activate* ./tls/bin/get_deactivated_path.lua
+rm ./tls/bin/tree-sitter ./tls/bin/json2lua ./tls/bin/lua2json
+rm ./tls/bin/luarocks ./tls/bin/luarocks-admin ./tls/bin/tl
+
+tls_dir="$(pwd)/tls/"
+sed -i '' -e '2i\
+cd "$(dirname "$0")"' ./tls/bin/teal-language-server
+sed -i '' -e "s*$tls_dir*../*g" ./tls/bin/teal-language-server
+
+teal-language-server --help

--- a/scripts/create_binary.sh
+++ b/scripts/create_binary.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-# python3 -m pip install hererocks
+python3 -m pip install hererocks
 hererocks -l "@v5.4.7" -r "@v3.11.1" tls
 
 source tls/bin/activate

--- a/scripts/create_windows_binary.sh
+++ b/scripts/create_windows_binary.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# make this our "main" folder
+mv luarocks teal-language-server
+
+# install lua
+mv .lua/bin/lua.exe teal-language-server/bin/
+mv .lua/bin/lua54.dll teal-language-server/bin/
+
+# clean out bin
+cd teal-language-server/bin
+rm -f json2lua.bat lua2json.bat tl.bat
+
+# modify teal-language-server.bat
+# a bit hacky, but should preseve some version numbers
+sed -i 's*set "LUAROCKS_SYSCONFDIR=C:\\Program Files\\luarocks"*cd /D "%~dp0"*g' teal-language-server.bat
+sed -i 's*D:\\a\\teal-language-server\\teal-language-server\\.lua\\bin\\lua.exe*.\\lua.exe*g' teal-language-server.bat
+sed -i 's*D:\\\\a\\\\teal-language-server\\\\teal-language-server\\\\luarocks*..*g' teal-language-server.bat
+sed -i 's*D:\\a\\teal-language-server\\teal-language-server\\luarocks*..*g' teal-language-server.bat


### PR DESCRIPTION
This allows us to upload binaries on releases to make it easier for folks to use teal-language-server!

- Automatically create binaries for Mac and Windows
  - Runs when tagging a release and when a PR is opened

It looks like on some versions of macOS, since the lua binary doesn't get signed you have to allow the terminal/your editor access to run software locally. This setting is in Privacy and Security -> Developer Tools

![image](https://github.com/user-attachments/assets/93bbbc8b-cb2c-4caf-b4f1-6b28931be737)

(this doesn't seem to be an issue if you build the software yourself)

I'm planning to update some of the dependencies, update the README, and then will cut a new release with the binaries attached,

closes #47 