### PR TITLE
Find Teal packages installed in virtual env or system-wide even if tls is not

### DIFF
--- a/gen/teal_language_server/env_updater.lua
+++ b/gen/teal_language_server/env_updater.lua
@@ -2,6 +2,7 @@ local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 th
 
 
 local DocumentManager = require("teal_language_server.document_manager")
+local lua_env = require("teal_language_server.lua_env")
 local lusc = require("lusc")
 local ServerState = require("teal_language_server.server_state")
 local tl = require("tl")
@@ -13,6 +14,8 @@ local class = require("teal_language_server.class")
 
 local init_path = package.path
 local init_cpath = package.cpath
+local discovered_user_path = nil
+local discovered_user_cpath = nil
 
 local EnvUpdater = {}
 
@@ -105,6 +108,16 @@ function EnvUpdater:_generate_env()
    package.path = init_path
    package.cpath = init_cpath
 
+
+
+
+   if discovered_user_path then
+      package.path = package.path .. ";" .. discovered_user_path
+   end
+   if discovered_user_cpath then
+      package.cpath = package.cpath .. ";" .. discovered_user_cpath
+   end
+
    local env, errs = self:_init_env_from_config(config)
 
    if errs ~= nil and #errs > 0 then
@@ -154,6 +167,14 @@ function EnvUpdater:schedule_env_update()
 end
 
 function EnvUpdater:initialize()
+   local root = self._server_state.teal_project_root_dir.value
+   local lua_bin = lua_env.find_lua_bin(root)
+   tracing.info(_module_name, "Using lua binary for env discovery: {}", { lua_bin })
+   discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
+   if discovered_user_path then
+      tracing.info(_module_name, "Discovered user lua path: {}", { discovered_user_path })
+   end
+
    local env = self:_generate_env()
    self._server_state:set_env(env)
 

--- a/gen/teal_language_server/env_updater.lua
+++ b/gen/teal_language_server/env_updater.lua
@@ -1,4 +1,4 @@
-local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local package = _tl_compat and _tl_compat.package or package; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local _module_name = "env_updater"
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local package = _tl_compat and _tl_compat.package or package; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local _module_name = "env_updater"
 
 
 local DocumentManager = require("teal_language_server.document_manager")
@@ -14,8 +14,20 @@ local class = require("teal_language_server.class")
 
 local init_path = package.path
 local init_cpath = package.cpath
-local discovered_user_path = nil
-local discovered_user_cpath = nil
+
+local function dedup_path(path_str)
+   local seen = {}
+   local result = {}
+
+
+   for entry in path_str:gmatch("[^;]+") do
+      if not seen[entry] then
+         seen[entry] = true
+         table.insert(result, entry)
+      end
+   end
+   return table.concat(result, ";")
+end
 
 local EnvUpdater = {}
 
@@ -108,16 +120,6 @@ function EnvUpdater:_generate_env()
    package.path = init_path
    package.cpath = init_cpath
 
-
-
-
-   if discovered_user_path then
-      package.path = package.path .. ";" .. discovered_user_path
-   end
-   if discovered_user_cpath then
-      package.cpath = package.cpath .. ";" .. discovered_user_cpath
-   end
-
    local env, errs = self:_init_env_from_config(config)
 
    if errs ~= nil and #errs > 0 then
@@ -170,9 +172,15 @@ function EnvUpdater:initialize()
    local root = self._server_state.teal_project_root_dir.value
    local lua_bin = lua_env.find_lua_bin(root)
    tracing.info(_module_name, "Using lua binary for env discovery: {}", { lua_bin })
-   discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
+   local discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
    if discovered_user_path then
+      init_path = dedup_path(init_path .. ";" .. discovered_user_path)
       tracing.info(_module_name, "Discovered user lua path: {}", { discovered_user_path })
+   end
+
+   if discovered_user_cpath then
+      init_cpath = dedup_path(init_cpath .. ";" .. discovered_user_cpath)
+      tracing.info(_module_name, "Discovered user lua cpath: {}", { discovered_user_cpath })
    end
 
    local env = self:_generate_env()

--- a/gen/teal_language_server/lua_env.lua
+++ b/gen/teal_language_server/lua_env.lua
@@ -1,0 +1,76 @@
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local io = _tl_compat and _tl_compat.io or io; local string = _tl_compat and _tl_compat.string or string; local _module_name = "lua_env"
+
+local uv = require("luv")
+local util = require("teal_language_server.util")
+local tracing = require("teal_language_server.tracing")
+
+local lua_env = {}
+
+
+
+
+function lua_env.find_lua_bin(workspace_root)
+   local bin_name = util.get_platform() == "windows" and "lua.exe" or "lua"
+
+   local req = uv.fs_scandir(workspace_root)
+   if req then
+      while true do
+         local name = uv.fs_scandir_next(req)
+         if not name then break end
+         local candidate = workspace_root .. "/" .. name .. "/bin/" .. bin_name
+         local stat = uv.fs_stat(candidate)
+         if stat ~= nil and stat.type == "file" then
+            tracing.debug(_module_name, "Found lua binary at {}", { candidate })
+            return candidate
+         end
+      end
+   end
+
+   tracing.debug(_module_name, "No local lua binary found, falling back to system {}", { bin_name })
+   return bin_name
+end
+
+
+
+
+function lua_env.discover_paths(lua_bin)
+   local is_windows = util.get_platform() == "windows"
+
+
+
+
+   local cmd
+   if is_windows then
+      cmd = '"' .. lua_bin .. '"' ..
+      [[ -e "pcall(require,'luarocks.loader'); io.write(package.path..'\n'..package.cpath)"]]
+   else
+      cmd = '"' .. lua_bin .. '"' ..
+      [[ -e 'pcall(require,"luarocks.loader"); io.write(package.path.."\n"..package.cpath)']]
+   end
+
+   tracing.debug(_module_name, "Running lua path discovery: {}", { cmd })
+
+   local handle = io.popen(cmd)
+   if not handle then
+      tracing.warning(_module_name, "Failed to open pipe to lua binary for path discovery", {})
+      return nil, nil
+   end
+
+   local output = handle:read("*a")
+   handle:close()
+
+   if not output or #output == 0 then
+      tracing.warning(_module_name, "Lua binary produced no output during path discovery", {})
+      return nil, nil
+   end
+
+   local path, cpath = output:match("^([^\n]*)\n([^\n]*)")
+   if not path then
+      tracing.warning(_module_name, "Could not parse path discovery output: {}", { output })
+      return nil, nil
+   end
+
+   return path, cpath
+end
+
+return lua_env

--- a/src/teal_language_server/env_updater.tl
+++ b/src/teal_language_server/env_updater.tl
@@ -12,10 +12,22 @@ local asserts <const> = require("teal_language_server.asserts")
 local tracing <const> = require("teal_language_server.tracing")
 local class <const> = require("teal_language_server.class")
 
-local init_path <const> = package.path
-local init_cpath <const> = package.cpath
-local discovered_user_path: string = nil
-local discovered_user_cpath: string = nil
+local init_path: string = package.path
+local init_cpath: string = package.cpath
+
+local function dedup_path(path_str: string): string
+   local seen: {string: boolean} = {}
+   local result: {string} = {}
+   -- should keep the order, the de-duping feels a little risky, and this feels like it could be a premature optimzation?
+   -- I'll keep it for now and hope we wont regret it later
+   for entry in path_str:gmatch("[^;]+") do
+      if not seen[entry] then
+         seen[entry] = true
+         table.insert(result, entry)
+      end
+   end
+   return table.concat(result, ";")
+end
 
 local record EnvUpdater
    _document_manager: DocumentManager
@@ -108,16 +120,6 @@ function EnvUpdater:_generate_env(): tl.Env
    package.path = init_path
    package.cpath = init_cpath
 
-   -- append user's environment paths so tl.check can find their installed
-   -- .d.tl and .tl libraries; appending (not prepending) keeps the server's
-   -- own deps authoritative
-   if discovered_user_path then
-      package.path = package.path .. ";" .. discovered_user_path
-   end
-   if discovered_user_cpath then
-      package.cpath = package.cpath .. ";" .. discovered_user_cpath
-   end
-
    local env, errs = self:_init_env_from_config(config)
 
    if errs ~= nil and #errs > 0 then
@@ -170,9 +172,15 @@ function EnvUpdater:initialize()
    local root = self._server_state.teal_project_root_dir.value
    local lua_bin = lua_env.find_lua_bin(root)
    tracing.info(_module_name, "Using lua binary for env discovery: {}", {lua_bin})
-   discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
+   local discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
    if discovered_user_path then
+      init_path = dedup_path(init_path .. ";" .. discovered_user_path)
       tracing.info(_module_name, "Discovered user lua path: {}", {discovered_user_path})
+   end
+
+   if discovered_user_cpath then
+      init_cpath = dedup_path(init_cpath .. ";" .. discovered_user_cpath)
+      tracing.info(_module_name, "Discovered user lua cpath: {}", {discovered_user_cpath})
    end
 
    local env = self:_generate_env()

--- a/src/teal_language_server/env_updater.tl
+++ b/src/teal_language_server/env_updater.tl
@@ -2,6 +2,7 @@ local _module_name = "env_updater"
 
 -- <imports>
 local DocumentManager <const> = require("teal_language_server.document_manager")
+local lua_env <const> = require("teal_language_server.lua_env")
 local lusc <const> = require("lusc")
 local ServerState <const> = require("teal_language_server.server_state")
 local tl <const> = require("tl")
@@ -13,6 +14,8 @@ local class <const> = require("teal_language_server.class")
 
 local init_path <const> = package.path
 local init_cpath <const> = package.cpath
+local discovered_user_path: string = nil
+local discovered_user_cpath: string = nil
 
 local record EnvUpdater
    _document_manager: DocumentManager
@@ -105,6 +108,16 @@ function EnvUpdater:_generate_env(): tl.Env
    package.path = init_path
    package.cpath = init_cpath
 
+   -- append user's environment paths so tl.check can find their installed
+   -- .d.tl and .tl libraries; appending (not prepending) keeps the server's
+   -- own deps authoritative
+   if discovered_user_path then
+      package.path = package.path .. ";" .. discovered_user_path
+   end
+   if discovered_user_cpath then
+      package.cpath = package.cpath .. ";" .. discovered_user_cpath
+   end
+
    local env, errs = self:_init_env_from_config(config)
 
    if errs ~= nil and #errs > 0 then
@@ -154,6 +167,14 @@ function EnvUpdater:schedule_env_update()
 end
 
 function EnvUpdater:initialize()
+   local root = self._server_state.teal_project_root_dir.value
+   local lua_bin = lua_env.find_lua_bin(root)
+   tracing.info(_module_name, "Using lua binary for env discovery: {}", {lua_bin})
+   discovered_user_path, discovered_user_cpath = lua_env.discover_paths(lua_bin)
+   if discovered_user_path then
+      tracing.info(_module_name, "Discovered user lua path: {}", {discovered_user_path})
+   end
+
    local env = self:_generate_env()
    self._server_state:set_env(env)
 

--- a/src/teal_language_server/lua_env.tl
+++ b/src/teal_language_server/lua_env.tl
@@ -1,0 +1,76 @@
+local _module_name = "lua_env"
+
+local uv <const> = require("luv")
+local util <const> = require("teal_language_server.util")
+local tracing <const> = require("teal_language_server.tracing")
+
+local record lua_env
+end
+
+-- Scan one level deep under workspace_root for any */bin/lua[.exe].
+-- Returns the first match, or falls back to the system lua binary name.
+function lua_env.find_lua_bin(workspace_root: string): string
+   local bin_name = util.get_platform() == "windows" and "lua.exe" or "lua"
+
+   local req = uv.fs_scandir(workspace_root)
+   if req then
+      while true do
+         local name = uv.fs_scandir_next(req)
+         if not name then break end
+         local candidate = workspace_root .. "/" .. name .. "/bin/" .. bin_name
+         local stat = uv.fs_stat(candidate)
+         if stat ~= nil and stat.type == "file" then
+            tracing.debug(_module_name, "Found lua binary at {}", {candidate})
+            return candidate
+         end
+      end
+   end
+
+   tracing.debug(_module_name, "No local lua binary found, falling back to system {}", {bin_name})
+   return bin_name
+end
+
+-- Spawn lua_bin with an inline script that activates the luarocks loader (if
+-- present) then writes package.path and package.cpath to stdout.  Returns the
+-- two path strings, or nil, nil on any failure.
+function lua_env.discover_paths(lua_bin: string): string, string
+   local is_windows = util.get_platform() == "windows"
+
+   -- Quote the binary so paths with spaces survive shell expansion.
+   -- On Windows (cmd.exe) use double-quotes around the script; on Unix use
+   -- single-quotes so the inner double-quotes reach Lua unmodified.
+   local cmd: string
+   if is_windows then
+      cmd = '"' .. lua_bin .. '"' ..
+         [[ -e "pcall(require,'luarocks.loader'); io.write(package.path..'\n'..package.cpath)"]]
+   else
+      cmd = '"' .. lua_bin .. '"' ..
+         [[ -e 'pcall(require,"luarocks.loader"); io.write(package.path.."\n"..package.cpath)']]
+   end
+
+   tracing.debug(_module_name, "Running lua path discovery: {}", {cmd})
+
+   local handle = io.popen(cmd)
+   if not handle then
+      tracing.warning(_module_name, "Failed to open pipe to lua binary for path discovery", {})
+      return nil, nil
+   end
+
+   local output = handle:read("*a")
+   handle:close()
+
+   if not output or #output == 0 then
+      tracing.warning(_module_name, "Lua binary produced no output during path discovery", {})
+      return nil, nil
+   end
+
+   local path, cpath = output:match("^([^\n]*)\n([^\n]*)")
+   if not path then
+      tracing.warning(_module_name, "Could not parse path discovery output: {}", {output})
+      return nil, nil
+   end
+
+   return path, cpath
+end
+
+return lua_env

--- a/teal-language-server-0.1.4-1.rockspec
+++ b/teal-language-server-0.1.4-1.rockspec
@@ -44,6 +44,7 @@ build = {
       ["teal_language_server.document"] = "gen/teal_language_server/document.lua",
       ["teal_language_server.document_manager"] = "gen/teal_language_server/document_manager.lua",
       ["teal_language_server.env_updater"] = "gen/teal_language_server/env_updater.lua",
+      ["teal_language_server.lua_env"] = "gen/teal_language_server/lua_env.lua",
       ["teal_language_server.lsp"] = "gen/teal_language_server/lsp.lua",
       ["teal_language_server.lsp_events_manager"] = "gen/teal_language_server/lsp_events_manager.lua",
       ["teal_language_server.lsp_formatter"] = "gen/teal_language_server/lsp_formatter.lua",

--- a/types/cjson.d.tl
+++ b/types/cjson.d.tl
@@ -6,7 +6,7 @@ local record cjson
    encode: function({string:any}): string
    decode: function(string): {string:any}
    null: Null
-   empty_array_mt: metatable
+   empty_array_mt: metatable<any>
 end
 
 return cjson


### PR DESCRIPTION
For people using the Windows binary or have installed teal-language-server in a non-system wide Lua environment, we now pull in the `package.path` and `package.cpath` from `./*/bin/lua` and then `lua` on PATH if not found.

closes #62 