### PR TITLE
Added goto definition, renamed old goto definition to goto type definition

### DIFF
--- a/docs/type_report_lookups.md
+++ b/docs/type_report_lookups.md
@@ -1,0 +1,115 @@
+# TypeReport Lookups
+
+NOTE: this document is AI generated, I had it read through what was already in place and write this up after not having worked on some of the internals for a few months... Do I wish I had written something like this up myself back in late 2024? Yes, yes I do.
+
+## The `tl.TypeReport` structures
+
+After a successful `tl.check` run the type checker populates a `TypeReport` on the shared
+environment. Four structures matter for LSP features:
+
+```
+TypeReport
+  types:          {type_id → TypeInfo}
+  globals:        {name → type_id}
+  by_pos:         {file → {line → {col → type_id}}}
+  symbols_by_file:{file → {Symbol}}   -- Symbol = {y, x, name, type_id}
+```
+
+### `types` — type declarations
+
+Maps every type ID to a `TypeInfo` record. The `y`/`x` fields on a `TypeInfo` point to
+**where the type itself is declared** (e.g. `record TestType` on line 0, `function` keyword
+on line 4). Other useful fields: `str` (display string), `fields` (record field names →
+type_id), `args`/`rets` (function parameter/return types), `ref` (nominal indirection).
+
+### `globals` — global name bindings
+
+Maps a global name to its type_id. Use this as a fallback after `symbols_in_scope` fails.
+
+### `by_pos` — position-keyed inverse index
+
+Maps `(file, line, col)` → type_id. Logically the inverse of looking up a type by
+position. Currently disabled in `Document:type_information_for_tokens` because it caused
+more regressions than it helped (see the commented-out block in `document.tl`). Reserved
+for future use.
+
+### `symbols_by_file` — symbol declarations (name bindings)
+
+An **ordered list** of symbol entries per file. Each `Symbol` tuple is `{y, x, name,
+type_id}` where `y`/`x` are **where the name was bound** (e.g. `local a` on line 31), not
+where its type is declared. Two special pseudo-symbols mark scope boundaries:
+
+| `name` field | Meaning |
+|---|---|
+| `@{` | scope block opens here |
+| `@}` | scope block closes here; `type_id` field holds the list-index of the matching `@{` |
+
+---
+
+## The two fundamental questions
+
+Every LSP feature asks one of two questions about a token:
+
+**"Where is this *type* declared?"** → `TypeInfo.y / TypeInfo.x`
+
+For `local a: TestType`, this leads to `record TestType`. Useful when you want to know the
+shape/contract of a value.
+
+**"Where is this *name* bound?"** → a Symbol's `y / x` from `symbols_by_file`
+
+For `local a: TestType`, this leads to `local a`. Useful when you want the declaration of
+the variable itself.
+
+These two answers coincide only when a type is declared at the same location it is first
+bound — most notably a **local function declaration** (`local function my_func()`).
+
+---
+
+## Resolution utilities
+
+### `tl.symbols_in_scope(tr, y, x, file)` → `{name: type_id}`
+
+Walks `symbols_by_file` **backwards** from `(y, x)`, honoring the `@{`/`@}` scope markers:
+
+- On `@{`: step past it (already inside this scope, keep going outward).
+- On `@}`: jump to the matching `@{` index — this skips an entire sibling block that closed
+  before the cursor, whose locals are out of scope.
+- On a normal symbol: record `name → type_id` only if not already recorded (innermost
+  wins, implementing shadowing).
+
+Returns the map of all names visible at the cursor. **Discards positions** — you get
+type_ids only, not where the names were declared.
+
+### `Document:type_information_for_tokens(tokens, y, x)` → `TypeInfo`
+
+The main resolution chain used by most LSP features:
+
+1. Calls `symbols_in_scope` to build the in-scope name map.
+2. Resolves `tokens[1]` in that map (falls back to `tr.globals`).
+3. For each subsequent token, walks `TypeInfo.fields` to follow field accesses.
+4. Returns the final `TypeInfo`, whose `y`/`x` point to the **type** declaration.
+
+### `Document:symbol_declaration_position(name, y, x)` → `(y, x)`
+
+Mirrors the `symbols_in_scope` backwards walk but, on a match, returns the matched
+Symbol's `y`/`x` — the **declaration site of the name itself**. Used exclusively by
+`textDocument/definition` for base symbols.
+
+---
+
+## LSP features: which lookup, and why
+
+| Feature | Lookup used | Why |
+|---|---|---|
+| `textDocument/hover` | `type_information_for_tokens` → `TypeInfo.str` / `fields` / `args` | Needs the *shape* of the value (type string, field list, function signature) for display. The type's declaration position is not used. |
+| `textDocument/completion` | `type_information_for_tokens` → `TypeInfo.fields` / `keys` / `enums` | Needs the set of valid field/method names to offer. For `:` completions, also inspects `TypeInfo.args[1]` to filter to self-methods only. |
+| `textDocument/signatureHelp` | `type_information_for_tokens` → `TypeInfo.args` | Needs the parameter names and types of the function being called. |
+| `textDocument/typeDefinition` | `type_information_for_tokens` → `TypeInfo.y` / `TypeInfo.x` | Intentionally jumps to the *type* declaration. This is what `textDocument/definition` used to do before the distinction was introduced. |
+| `textDocument/definition` (base symbol) | `symbol_declaration_position` → Symbol `y`/`x` | Jumps to where the *name was bound*. `local a: TestType` → `local a`, not `record TestType`. Falls back to `type_information_for_tokens` if the symbol isn't tracked (e.g. a global). |
+| `textDocument/definition` (field access) | `type_information_for_tokens` → `TypeInfo.y` / `TypeInfo.x` | The field's `TypeInfo` carries its declaration position for record/function fields, which is correct and works cross-file. Falls back to the *enclosing record's* `TypeInfo` when the field's type has no position (e.g. primitive `boolean`). |
+
+### Summary rule of thumb
+
+- Displaying or completing **what a value is** → `type_information_for_tokens` → `TypeInfo`
+- Jumping to **where a type is declared** → `TypeInfo.y` / `TypeInfo.x`
+- Jumping to **where a name is declared** → `symbol_declaration_position` → Symbol `y`/`x`

--- a/gen/teal_language_server/document.lua
+++ b/gen/teal_language_server/document.lua
@@ -402,6 +402,52 @@ function Document:type_information_for_tokens(tokens, y, x)
    return nil
 end
 
+
+
+
+
+function Document:symbol_declaration_position(name, y, x)
+   local tr = self:get_type_report()
+   local symbols = tr.symbols_by_file[self._uri.path]
+   if not symbols then
+      return nil
+   end
+
+
+
+
+   local target_y = y + 1
+   local target_x = x + 1
+   local n = 0
+   for i = 1, #symbols do
+      local s = symbols[i]
+      if s[1] < target_y or (s[1] == target_y and s[2] <= target_x) then
+         n = i
+      else
+         break
+      end
+   end
+
+
+
+   while n >= 1 do
+      local s = symbols[n]
+      local symbol_name = s[3]
+      if symbol_name == "@{" then
+         n = n - 1
+      elseif symbol_name == "@}" then
+         n = s[4]
+      else
+         if symbol_name == name then
+            return s[1], s[2]
+         end
+         n = n - 1
+      end
+   end
+
+   return nil
+end
+
 function Document:_tree_sitter_token(y, x)
    local moved = self._tree_cursor:goto_first_child()
    local node = self._tree_cursor:current_node()

--- a/gen/teal_language_server/lsp.lua
+++ b/gen/teal_language_server/lsp.lua
@@ -158,6 +158,7 @@ local lsp = { Message = { ResponseError = {} }, Position = {}, Range = {}, Locat
 
 
 
+
 lsp.error_code = {
    InternalError = -32603,
    InvalidParams = -32602,

--- a/gen/teal_language_server/misc_handlers.lua
+++ b/gen/teal_language_server/misc_handlers.lua
@@ -150,6 +150,19 @@ local function split_by_symbols(input, self_type, stop_at)
    return t
 end
 
+
+
+
+
+
+local function tokens_for_node(node_info, self_type)
+   if indexable_parent_types[node_info.parent_type] then
+      return split_by_symbols(node_info.parent_source, self_type, node_info.source)
+   else
+      return split_by_symbols(node_info.source, self_type)
+   end
+end
+
 function MiscHandlers:_get_node_info(params, pos)
    local context = params.context
 
@@ -377,6 +390,45 @@ function MiscHandlers:_on_signature_help(params, id)
    self._lsp_reader_writer:send_rpc(id, output)
 end
 
+
+
+
+function MiscHandlers:_send_location(id, doc, file, y, x)
+   if file == nil or y == nil or x == nil then
+      return false
+   end
+
+   local file_uri
+
+   if #file == 0 or file == doc.uri.path then
+      file_uri = doc.uri
+   else
+      local full_path
+
+      if Path(file):is_absolute() then
+         full_path = file
+      else
+         full_path = self._server_state.teal_project_root_dir.value .. "/" .. file
+      end
+
+      file_uri = Uri.uri_from_path(Path(full_path).value)
+   end
+
+   self._lsp_reader_writer:send_rpc(id, {
+      uri = Uri.tostring(file_uri),
+      range = {
+         start = lsp.position(y - 1, x - 1),
+         ["end"] = lsp.position(y - 1, x - 1),
+      },
+   })
+   return true
+end
+
+
+
+
+
+
 function MiscHandlers:_on_definition(params, id)
    local pos = params.position
    local node_info, doc = self:_get_node_info(params, pos)
@@ -387,53 +439,74 @@ function MiscHandlers:_on_definition(params, id)
 
    tracing.trace(_module_name, "Received request for on_definition at position: {@}", { pos })
 
-   local tks = {}
-   if node_info.type == "identifier" then
-
-      if indexable_parent_types[node_info.parent_type] then
-         tks = split_by_symbols(node_info.parent_source, node_info.self_type, node_info.source)
-      else
-         tks = split_by_symbols(node_info.source, node_info.self_type)
-      end
-   else
-      tracing.warning(_module_name, "Can't hover over anything that isn't an identifier atm: {}", { node_info.type })
+   if node_info.type ~= "identifier" then
+      tracing.warning(_module_name, "Can't go to definition of anything that isn't an identifier atm: {}", { node_info.type })
       self._lsp_reader_writer:send_rpc(id, nil)
       return
    end
+
+   local tks = tokens_for_node(node_info, "self")
+
+
+   if #tks == 1 then
+      local decl_y, decl_x = doc:symbol_declaration_position(tks[1], pos.line, pos.character)
+      if decl_y ~= nil and self:_send_location(id, doc, doc.uri.path, decl_y, decl_x) then
+         return
+      end
+
+
+   end
+
+
 
    local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
+   if type_info and self:_send_location(id, doc, type_info.file, type_info.y, type_info.x) then
+      tracing.trace(_module_name, "[on_definition] Resolved via field/type position", {})
+      return
+   end
 
-   if not type_info or type_info.file == nil then
+
+
+   if #tks > 1 then
+      local parent_tks = {}
+      for i = 1, #tks - 1 do parent_tks[i] = tks[i] end
+      local parent_info = doc:type_information_for_tokens(parent_tks, pos.line, pos.character)
+      if parent_info and self:_send_location(id, doc, parent_info.file, parent_info.y, parent_info.x) then
+         tracing.trace(_module_name, "[on_definition] Resolved via enclosing record position", {})
+         return
+      end
+   end
+
+   self._lsp_reader_writer:send_rpc(id, nil)
+end
+
+
+
+
+function MiscHandlers:_on_type_definition(params, id)
+   local pos = params.position
+   local node_info, doc = self:_get_node_info(params, pos)
+   if node_info == nil then
       self._lsp_reader_writer:send_rpc(id, nil)
       return
    end
 
-   tracing.trace(_module_name, "[on_definition] Found type type_info: {}", { type_info })
+   tracing.trace(_module_name, "Received request for on_type_definition at position: {@}", { pos })
 
-   local file_uri
-
-   if #type_info.file == 0 or type_info.file == doc.uri.path then
-      file_uri = doc.uri
-   else
-      local full_path
-
-      if Path(type_info.file):is_absolute() then
-         full_path = type_info.file
-      else
-         full_path = self._server_state.teal_project_root_dir.value .. "/" .. type_info.file
-      end
-
-      local file_path = Path(full_path)
-      file_uri = Uri.uri_from_path(file_path.value)
+   if node_info.type ~= "identifier" then
+      tracing.warning(_module_name, "Can't go to type definition of anything that isn't an identifier atm: {}", { node_info.type })
+      self._lsp_reader_writer:send_rpc(id, nil)
+      return
    end
 
-   self._lsp_reader_writer:send_rpc(id, {
-      uri = Uri.tostring(file_uri),
-      range = {
-         start = lsp.position(type_info.y - 1, type_info.x - 1),
-         ["end"] = lsp.position(type_info.y - 1, type_info.x - 1),
-      },
-   })
+   local tks = tokens_for_node(node_info, "self")
+   local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
+
+   tracing.trace(_module_name, "[on_type_definition] Found type type_info: {}", { type_info })
+
+   if not type_info or not self:_send_location(id, doc, type_info.file, type_info.y, type_info.x) then
+      self._lsp_reader_writer:send_rpc(id, nil)
+   end
 end
 
 function MiscHandlers:_on_hover(params, id)
@@ -512,8 +585,8 @@ function MiscHandlers:initialize()
    self:_add_handler("textDocument/signatureHelp", self._on_signature_help)
    self:_add_handler("textDocument/hover", self._on_hover)
 
-
    self:_add_handler("textDocument/definition", self._on_definition)
+   self:_add_handler("textDocument/typeDefinition", self._on_type_definition)
 end
 
 class.setup(MiscHandlers, "MiscHandlers", {})

--- a/gen/teal_language_server/server_state.lua
+++ b/gen/teal_language_server/server_state.lua
@@ -40,6 +40,7 @@ local capabilities = {
    },
    hoverProvider = true,
    definitionProvider = true,
+   typeDefinitionProvider = true,
    completionProvider = {
       triggerCharacters = { ".", ":" },
    },

--- a/src/teal_language_server/document.tl
+++ b/src/teal_language_server/document.tl
@@ -402,6 +402,52 @@ function Document:type_information_for_tokens(tokens: {string}, y: integer, x: i
    return nil
 end
 
+-- Finds where a symbol named `name` was *declared* (as opposed to where its type
+-- is declared). Mirrors the backward scope walk in tl.symbols_in_scope, but
+-- returns the matched symbol's declaration position instead of its type id.
+-- `y`/`x` are 0-indexed (LSP); the returned y/x are 1-indexed (tl convention).
+function Document:symbol_declaration_position(name: string, y: integer, x: integer): integer, integer
+   local tr <const> = self:get_type_report()
+   local symbols = tr.symbols_by_file[self._uri.path]
+   if not symbols then
+      return nil
+   end
+
+   -- Symbols are stored in source order, so the last one whose position is at or
+   -- before the cursor is our starting point. (tl uses a binary search here, but
+   -- that helper is private to tl, so we scan linearly.)
+   local target_y <const> = y + 1
+   local target_x <const> = x + 1
+   local n = 0
+   for i = 1, #symbols do
+      local s = symbols[i]
+      if s[1] < target_y or (s[1] == target_y and s[2] <= target_x) then
+         n = i
+      else
+         break
+      end
+   end
+
+   -- Walk backwards, honoring the @{ / @} scope markers, and return the position
+   -- of the nearest in-scope declaration matching `name`.
+   while n >= 1 do
+      local s = symbols[n]
+      local symbol_name = s[3]
+      if symbol_name == "@{" then
+         n = n - 1
+      elseif symbol_name == "@}" then
+         n = s[4]
+      else
+         if symbol_name == name then
+            return s[1], s[2]
+         end
+         n = n - 1
+      end
+   end
+
+   return nil
+end
+
 function Document:_tree_sitter_token(y: integer, x: integer): Document.NodeInfo
    local moved = self._tree_cursor:goto_first_child()
    local node = self._tree_cursor:current_node()

--- a/src/teal_language_server/lsp.tl
+++ b/src/teal_language_server/lsp.tl
@@ -85,6 +85,7 @@ local record lsp
          "textDocument/didClose"
          "textDocument/hover"
          "textDocument/definition"
+         "textDocument/typeDefinition"
          "textDocument/publishDiagnostics"
          "textDocument/completion"
          "textDocument/signatureHelp"

--- a/src/teal_language_server/misc_handlers.tl
+++ b/src/teal_language_server/misc_handlers.tl
@@ -150,6 +150,19 @@ local function split_by_symbols(input: string, self_type: string, stop_at?: stri
    return t
 end
 
+-- Builds the token chain for a node under the cursor. For definition lookups we
+-- keep `self` literal (passing "self" as the self_type makes the substitution in
+-- split_by_symbols a no-op) so it resolves as a real in-scope parameter symbol
+-- rather than relying on the tree-sitter self_type detection, which is only set
+-- for named methods and not for function literals.
+local function tokens_for_node(node_info: Document.NodeInfo, self_type: string): {string}
+   if indexable_parent_types[node_info.parent_type] then
+      return split_by_symbols(node_info.parent_source, self_type, node_info.source)
+   else
+      return split_by_symbols(node_info.source, self_type)
+   end
+end
+
 function MiscHandlers:_get_node_info(params:lsp.Method.Params, pos: lsp.Position): Document.NodeInfo, Document
    local context = params.context as lsp.CompletionContext
 
@@ -377,6 +390,45 @@ function MiscHandlers:_on_signature_help(params:lsp.Method.Params, id:integer):n
    self._lsp_reader_writer:send_rpc(id, output)
 end
 
+-- Resolves a (possibly relative) source file path to a Uri and replies to `id`
+-- with an LSP Location pointing at the 1-indexed (y, x). Returns true if a
+-- location was sent, false if `file` was nil (no location available).
+function MiscHandlers:_send_location(id: integer, doc: Document, file: string, y: integer, x: integer): boolean
+   if file == nil or y == nil or x == nil then
+      return false
+   end
+
+   local file_uri: Uri
+
+   if #file == 0 or file == doc.uri.path then
+      file_uri = doc.uri
+   else
+      local full_path: string
+
+      if Path(file):is_absolute() then
+         full_path = file
+      else
+         full_path = self._server_state.teal_project_root_dir.value .. "/" .. file
+      end
+
+      file_uri = Uri.uri_from_path(Path(full_path).value)
+   end
+
+   self._lsp_reader_writer:send_rpc(id, {
+      uri = Uri.tostring(file_uri),
+      range = {
+         start = lsp.position(y - 1, x - 1),
+         ["end"] = lsp.position(y - 1, x - 1),
+      },
+   })
+   return true
+end
+
+-- "Go to definition": jump to where the *symbol* under the cursor is declared.
+-- For a base symbol this is its declaration site; for a field access it is where
+-- that field's type is declared (which works across files for record/function
+-- fields), falling back to the enclosing record's declaration when the field's
+-- type has no position (e.g. primitives like boolean).
 function MiscHandlers:_on_definition(params:lsp.Method.Params, id:integer):nil
    local pos <const> = params.position as lsp.Position
    local node_info, doc = self:_get_node_info(params, pos)
@@ -387,53 +439,74 @@ function MiscHandlers:_on_definition(params:lsp.Method.Params, id:integer):nil
 
    tracing.trace(_module_name, "Received request for on_definition at position: {@}", {pos})
 
-   local tks: {string} = {}
-   if node_info.type == "identifier" then
-      -- parent types that show up with multiparts
-      if indexable_parent_types[node_info.parent_type] then
-         tks = split_by_symbols(node_info.parent_source, node_info.self_type, node_info.source)
-      else
-         tks = split_by_symbols(node_info.source, node_info.self_type)
-      end
-   else
-      tracing.warning(_module_name, "Can't hover over anything that isn't an identifier atm: {}", {node_info.type})
+   if node_info.type ~= "identifier" then
+      tracing.warning(_module_name, "Can't go to definition of anything that isn't an identifier atm: {}", {node_info.type})
       self._lsp_reader_writer:send_rpc(id, nil)
       return
    end
 
+   local tks = tokens_for_node(node_info, "self")
+
+   -- Base symbol (e.g. `apple`, `self`, `TestType_mt`): go to its declaration.
+   if #tks == 1 then
+      local decl_y, decl_x = doc:symbol_declaration_position(tks[1], pos.line, pos.character)
+      if decl_y ~= nil and self:_send_location(id, doc, doc.uri.path, decl_y, decl_x) then
+         return
+      end
+      -- Not a tracked symbol (e.g. a global or a type name used as a value):
+      -- fall back to where its type is declared so we don't regress those.
+   end
+
+   -- Field access (e.g. `self.test_value`, `mod.func`): the field's type carries
+   -- the declaration position for record/function fields.
+   local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
+   if type_info and self:_send_location(id, doc, type_info.file, type_info.y, type_info.x) then
+      tracing.trace(_module_name, "[on_definition] Resolved via field/type position", {})
+      return
+   end
+
+   -- The field's type has no position (e.g. a primitive). Fall back to the
+   -- enclosing record's declaration.
+   if #tks > 1 then
+      local parent_tks: {string} = {}
+      for i = 1, #tks - 1 do parent_tks[i] = tks[i] end
+      local parent_info = doc:type_information_for_tokens(parent_tks, pos.line, pos.character)
+      if parent_info and self:_send_location(id, doc, parent_info.file, parent_info.y, parent_info.x) then
+         tracing.trace(_module_name, "[on_definition] Resolved via enclosing record position", {})
+         return
+      end
+   end
+
+   self._lsp_reader_writer:send_rpc(id, nil)
+end
+
+-- "Go to type definition": jump to where the *type* of the symbol under the
+-- cursor is declared. This is the behavior `textDocument/definition` previously
+-- had.
+function MiscHandlers:_on_type_definition(params:lsp.Method.Params, id:integer):nil
+   local pos <const> = params.position as lsp.Position
+   local node_info, doc = self:_get_node_info(params, pos)
+   if node_info == nil then
+      self._lsp_reader_writer:send_rpc(id, nil)
+      return
+   end
+
+   tracing.trace(_module_name, "Received request for on_type_definition at position: {@}", {pos})
+
+   if node_info.type ~= "identifier" then
+      tracing.warning(_module_name, "Can't go to type definition of anything that isn't an identifier atm: {}", {node_info.type})
+      self._lsp_reader_writer:send_rpc(id, nil)
+      return
+   end
+
+   local tks = tokens_for_node(node_info, "self")
    local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
 
-   if not type_info or type_info.file == nil then
+   tracing.trace(_module_name, "[on_type_definition] Found type type_info: {}", {type_info})
+
+   if not type_info or not self:_send_location(id, doc, type_info.file, type_info.y, type_info.x) then
       self._lsp_reader_writer:send_rpc(id, nil)
-      return
    end
-
-   tracing.trace(_module_name, "[on_definition] Found type type_info: {}", {type_info})
-
-   local file_uri: Uri
-
-   if #type_info.file == 0 or type_info.file == doc.uri.path then
-      file_uri = doc.uri
-   else
-      local full_path: string
-
-      if Path(type_info.file):is_absolute() then
-         full_path = type_info.file
-      else
-         full_path = self._server_state.teal_project_root_dir.value .. "/" .. type_info.file
-      end
-
-      local file_path = Path(full_path)
-      file_uri = Uri.uri_from_path(file_path.value)
-   end
-
-   self._lsp_reader_writer:send_rpc(id, {
-      uri = Uri.tostring(file_uri),
-      range = {
-         start = lsp.position(type_info.y - 1, type_info.x - 1),
-         ["end"] = lsp.position(type_info.y - 1, type_info.x - 1),
-      },
-   })
 end
 
 function MiscHandlers:_on_hover(params:lsp.Method.Params, id:integer):nil
@@ -512,8 +585,8 @@ function MiscHandlers:initialize()
    self:_add_handler("textDocument/signatureHelp", self._on_signature_help)
    self:_add_handler("textDocument/hover", self._on_hover)
 
-   -- planning to figure out what defintion/declaration vs type definition/declaration should go to
    self:_add_handler("textDocument/definition", self._on_definition)
+   self:_add_handler("textDocument/typeDefinition", self._on_type_definition)
 end
 
 class.setup(MiscHandlers, "MiscHandlers", {

--- a/src/teal_language_server/server_state.tl
+++ b/src/teal_language_server/server_state.tl
@@ -40,6 +40,7 @@ local capabilities = {
    },
    hoverProvider = true,
    definitionProvider = true,
+   typeDefinitionProvider = true,
    completionProvider = {
       triggerCharacters = { ".", ":" },
    },

--- a/tests/definition_sample_file_test.lua
+++ b/tests/definition_sample_file_test.lua
@@ -1,0 +1,273 @@
+package.path = "./?.lua;" .. package.path
+
+local tested = require("tested")
+local LspClient = require("tests.helpers.lsp_client")
+
+-- Document mirrors test/sample-file.tl exactly.
+-- Line numbers below are 0-indexed (LSP convention).
+--
+-- Line  0: local record TestType
+-- Line  1:   test_value: boolean
+-- Line  2: (blank)
+-- Line  3:   metamethod __call: function(self: TestType): boolean
+-- Line  4: end
+-- Line  5: (blank)
+-- Line  6: local TestType_mt: metatable<TestType>
+-- Lines 7-10: block comment
+-- Line 11: TestType_mt = {
+-- Line 12:   __call = function(self: TestType): boolean
+-- Lines 13-19: block comment
+-- Line 20:     return self.test_value
+-- Lines 21-22: end / }
+-- Line 23: (blank)
+-- Lines 24-30: block comment
+-- Line 31: local a: TestType = setmetatable({test_value = true}, TestType_mt)
+-- Line 32: (blank)
+-- Lines 33-36: block comment
+-- Line 37: a()
+local doc = [=[
+local record TestType
+  test_value: boolean
+
+  metamethod __call: function(self: TestType): boolean
+end
+
+local TestType_mt: metatable<TestType>
+--[[
+  trying textDocument/definition on `TestType_mt` attempts to go to the definition for `metatable` in stdlib.d.tl
+  - should always go to `local TestType_mt`
+]]
+TestType_mt = {
+  __call = function(self: TestType): boolean
+    --[[
+      trying textDocument/definition on `self` fails (No LSP Definitions found)
+      - should go to `self` in the function parameters
+
+      trying textDocument/definition on `test_value` fails (No LSP Definitions found)
+      - should go to `test_value` within `local record TestType`
+    ]]
+    return self.test_value
+  end
+}
+
+--[[
+  trying textDocument/definition on `a` goes to `local record TestType`
+  - should go to itself as this is the definition
+
+  trying textDocument/definition on `test_value` fails (No LSP Definitions found)
+  - should either go to itself or to `test_value` within `local record TestType`
+]]
+local a: TestType = setmetatable({test_value = true}, TestType_mt)
+
+--[[
+  trying textDocument/definition on `a` goes to `local record TestType`
+  - should probably go to __call in the metatable, but could also reasonably go to `local a`
+]]
+a()
+]=]
+
+-- NOTE: Lua already drops the single newline immediately following the [=[
+-- opening long bracket, so `doc` starts at "local record TestType". Do NOT
+-- sub(2) here: that would strip the leading "l" of "local" and turn the whole
+-- document into a parse error, which silently disables type checking (and made
+-- every definition request below return null).
+
+local cjson = require("cjson")
+
+-- cjson decodes a JSON null as the userdata cjson.null, not Lua nil.
+-- Use this helper everywhere we guard against "no result".
+local function is_table(v)
+    return type(v) == "table"
+end
+
+local client
+local uri = "file:///tmp/tls_def_sample_file.tl"
+
+tested.before(function()
+    client = LspClient.new("teal-language-server")
+    client:initialize()
+    client:open_document(uri, doc)
+    client:wait_for_notification("textDocument/publishDiagnostics")
+end)
+
+tested.after(function()
+    if client then
+        client:shutdown()
+        client = nil
+    end
+end)
+
+-- Line 11: "TestType_mt = {", TestType_mt at col 0.
+-- Previously jumped to `metatable` in stdlib.d.tl (the type); now goes to the
+-- symbol declaration `local TestType_mt` on line 6.
+tested.test("definition of TestType_mt from usage site jumps to its local declaration", function()
+    local response = client:get_definition(uri, 11, 0)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "point to the same document (not stdlib)",
+        expected = uri,
+        actual = is_table(result) and result.uri,
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 6 (where local TestType_mt is declared)",
+        expected = 6,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 20: "    return self.test_value", self at col 11.
+-- Previously returned no result because self_type is nil for function literals (not named
+-- methods), causing split_by_symbols to insert nil as the first token. Now `self` is kept
+-- literal and resolved as an in-scope parameter symbol.
+tested.test("definition of self inside a function literal jumps to its parameter declaration", function()
+    local response = client:get_definition(uri, 20, 11)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 12 (where self: TestType is declared as a parameter)",
+        expected = 12,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 20: "    return self.test_value", test_value at col 16.
+-- The nil-token issue is fixed (self is kept literal), so the field access now resolves.
+-- tl's type report does not expose record-field positions, and `test_value`'s type
+-- (boolean) is a primitive with no position, so we fall back to the enclosing record's
+-- declaration (line 0, `local record TestType`) rather than the exact field on line 1.
+tested.test("definition of field access test_value in self.test_value jumps to its enclosing record", function()
+    local response = client:get_definition(uri, 20, 16)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 0 (the enclosing record TestType declaration)",
+        expected = 0,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 31: "local a: TestType = setmetatable(...)", a at col 6 (the declaration itself).
+-- Previously jumped to `local record TestType` (the type, line 0); now resolves to the
+-- symbol declaration, which is `a` itself on line 31.
+tested.test("definition of a at its own declaration jumps to itself", function()
+    local response = client:get_definition(uri, 31, 6)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 31 (the declaration itself)",
+        expected = 31,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 31: "local a: TestType = setmetatable({test_value = true}, ...)", test_value at col 34.
+-- Known limitation: table-literal keys are not tracked as symbols by tl, and the table's
+-- target type is not readily available at this node, so no result is returned. Ideally this
+-- would jump to `test_value: boolean` in TestType (line 1). Kept as an expected failure.
+tested.test("definition of test_value key in table literal jumps to its record field declaration", {expected="FAIL"}, function()
+    local response = client:get_definition(uri, 31, 34)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 1 (where test_value: boolean is declared in TestType)",
+        expected = 1,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 37: "a()", a at col 0 (the call site).
+-- Previously jumped to `local record TestType` (the type, line 0); now resolves to the
+-- symbol declaration `local a` on line 31.
+tested.test("definition of a at a call site jumps to its local declaration", function()
+    local response = client:get_definition(uri, 37, 0)
+    local result = response and response.result
+
+    tested.assert({
+        given = "definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "definition result range",
+        should = "point to line 31 (where local a is declared)",
+        expected = 31,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- textDocument/typeDefinition keeps the *type*-resolving behavior that
+-- textDocument/definition used to have.
+
+-- Line 37: "a()", a at col 0. typeDefinition resolves the type of `a` (TestType)
+-- and jumps to where that record is declared (line 0).
+tested.test("type definition of a jumps to its record type declaration", function()
+    local response = client:get_type_definition(uri, 37, 0)
+    local result = response and response.result
+
+    tested.assert({
+        given = "type definition result",
+        should = "point to the same document",
+        expected = uri,
+        actual = is_table(result) and result.uri,
+    })
+    tested.assert({
+        given = "type definition result range",
+        should = "point to line 0 (where record TestType is declared)",
+        expected = 0,
+        actual = is_table(result) and is_table(result.range) and result.range.start.line,
+    })
+end)
+
+-- Line 11: "TestType_mt = {", TestType_mt at col 0. typeDefinition resolves the
+-- type `metatable<TestType>` and jumps into the stdlib definition (a different file).
+tested.test("type definition of TestType_mt jumps to the metatable type in stdlib", function()
+    local response = client:get_type_definition(uri, 11, 0)
+    local result = response and response.result
+
+    tested.assert({
+        given = "type definition result",
+        should = "have a result",
+        expected = true,
+        actual = is_table(result),
+    })
+    tested.assert({
+        given = "type definition result uri",
+        should = "point to a different file (the stdlib, not the open document)",
+        expected = false,
+        actual = is_table(result) and (result.uri == uri),
+    })
+end)
+
+return tested

--- a/tests/helpers/lsp_client.lua
+++ b/tests/helpers/lsp_client.lua
@@ -313,6 +313,14 @@ function LspClient:get_definition(uri, line, character)
     return self:wait_for_response(id)
 end
 
+function LspClient:get_type_definition(uri, line, character)
+    local id = self:request("textDocument/typeDefinition", {
+        textDocument = { uri = uri },
+        position = { line = line, character = character },
+    })
+    return self:wait_for_response(id)
+end
+
 function LspClient:change_document(uri, text, version)
     self:notify("textDocument/didChange", {
         textDocument = { uri = uri, version = version or 2 },


### PR DESCRIPTION
I was looking into #48 and realized the "goto definition" was just going to the (easy to find) Teal type definition. I figured this might be more of a "type definition" vs "definition" separation.

AI Disclosure: AI wrote the TypeReport doc and was used in writing the symbol_declaration_position as well as turning the original issue into a test case.

This resolves most of the things brought up in #48, except going to definition in `local apple: TestType = setmetatable({test_value = true}, TestType_mt)` when hovering on `test_value`.

closes #48 