### PR TITLE
Check type on `params.rootUri` before using

### DIFF
--- a/gen/teal_language_server/handlers/misc_handlers.lua
+++ b/gen/teal_language_server/handlers/misc_handlers.lua
@@ -51,7 +51,8 @@ function MiscHandlers:_on_initialize(params, id)
    self._has_handled_initialize = true
    local root_dir_str
 
-   if params.rootUri then
+
+   if params.rootUri and type(params.rootUri) == "string" then
       root_dir_str = Uri.path_from_uri(params.rootUri)
    else
       root_dir_str = params.rootPath

--- a/src/teal_language_server/handlers/misc_handlers.tl
+++ b/src/teal_language_server/handlers/misc_handlers.tl
@@ -51,7 +51,8 @@ function MiscHandlers:_on_initialize(params:lsp.Method.Params, id:integer):nil
    self._has_handled_initialize= true
    local root_dir_str:string
 
-   if params.rootUri then
+   -- check type in case rootUri comes in as cjson.null
+   if params.rootUri and type(params.rootUri) == "string" then
       root_dir_str = Uri.path_from_uri(params.rootUri as string)
    else
       root_dir_str = params.rootPath as string


### PR DESCRIPTION
Helix appears to set this to `null` on new files, which become `cjson.null` and are truthy. This ensures it is a string before trying to use it.

As we expand out to support additional text editors, having fixes like this in place can be useful!

Fixes #77 