### PR TITLE
Degrade some common log warnings to info

### DIFF
--- a/gen/teal_language_server/analysis/document.lua
+++ b/gen/teal_language_server/analysis/document.lua
@@ -354,7 +354,7 @@ function Document:type_information_for_tokens(tokens, y, x)
    logger:trace("Processing token %s (all: %s)", raw_token, tokens)
    local type_id = scope_symbols[raw_token]
    if type_id == nil then
-      logger:warning("Failed to find type id for token %s", raw_token)
+      logger:info("Failed to find type id for token %s", raw_token)
    end
    if type_id ~= nil then
       logger:trace("Matched token %s to type id %s", raw_token, type_id)
@@ -370,7 +370,7 @@ function Document:type_information_for_tokens(tokens, y, x)
       type_info = tr.types[tr.globals[raw_token]]
 
       if type_info == nil then
-         logger:warning("Unable to find type info in global table as well..")
+         logger:info("Unable to find type info in global table as well..")
       end
    end
 
@@ -400,7 +400,7 @@ function Document:type_information_for_tokens(tokens, y, x)
       return type_info
    end
 
-   logger:warning("Failed to find type info at given position")
+   logger:info("Failed to find type info at given position")
    return nil
 end
 

--- a/gen/teal_language_server/handlers/handler_helper.lua
+++ b/gen/teal_language_server/handlers/handler_helper.lua
@@ -37,7 +37,7 @@ function handler_helper.get_node_info(document_manager, params, pos)
    local context = params.context
 
    if context and context.triggerKind ~= lsp.completion_trigger_kind.TriggerCharacter then
-      logger:warning("Ignoring completion request given kind: %s", context.triggerKind)
+      logger:info("Ignoring completion request given kind: %s", context.triggerKind)
       return nil
    end
 
@@ -52,7 +52,7 @@ function handler_helper.get_node_info(document_manager, params, pos)
    logger:debug("Looking up node info at position: %s", pos)
    local node_info = doc:tree_sitter_token(pos.line, pos.character)
    if node_info == nil then
-      logger:warning("Unable to retrieve node info from tree-sitter parser")
+      logger:info("Unable to retrieve node info from tree-sitter parser")
       return nil
    end
    logger:debug("Found node info: %s", node_info)

--- a/gen/teal_language_server/handlers/language_features.lua
+++ b/gen/teal_language_server/handlers/language_features.lua
@@ -82,7 +82,7 @@ function LanguageFeatureHandlers:_on_completion(params, id)
    local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
 
    if not type_info then
-      logger:warning("Also failed to find type type_info based on token")
+      logger:info("Also failed to find type type_info based on token")
    end
 
    if type_info then
@@ -146,7 +146,7 @@ function LanguageFeatureHandlers:_on_completion(params, id)
             end
          end
       else
-         logger:warning("Unable to get fields for ref type")
+         logger:info("Unable to get fields for ref type")
       end
    end
 

--- a/src/teal_language_server/analysis/document.tl
+++ b/src/teal_language_server/analysis/document.tl
@@ -354,7 +354,7 @@ function Document:type_information_for_tokens(tokens: {string}, y: integer, x: i
    logger:trace("Processing token %s (all: %s)", raw_token, tokens)
    local type_id <const> = scope_symbols[raw_token]
    if type_id == nil then
-      logger:warning("Failed to find type id for token %s", raw_token)
+      logger:info("Failed to find type id for token %s", raw_token)
    end
    if type_id ~= nil then
       logger:trace("Matched token %s to type id %s", raw_token, type_id)
@@ -370,7 +370,7 @@ function Document:type_information_for_tokens(tokens: {string}, y: integer, x: i
       type_info = tr.types[tr.globals[raw_token] ]
 
       if type_info == nil then
-         logger:warning("Unable to find type info in global table as well..")
+         logger:info("Unable to find type info in global table as well..")
       end
    end
 
@@ -400,7 +400,7 @@ function Document:type_information_for_tokens(tokens: {string}, y: integer, x: i
       return type_info
    end
 
-   logger:warning("Failed to find type info at given position")
+   logger:info("Failed to find type info at given position")
    return nil
 end
 

--- a/src/teal_language_server/handlers/handler_helper.tl
+++ b/src/teal_language_server/handlers/handler_helper.tl
@@ -37,7 +37,7 @@ function handler_helper.get_node_info(document_manager: DocumentManager, params:
    local context = params.context as lsp.CompletionContext
 
    if context and context.triggerKind ~= lsp.completion_trigger_kind.TriggerCharacter then
-      logger:warning("Ignoring completion request given kind: %s", context.triggerKind)
+      logger:info("Ignoring completion request given kind: %s", context.triggerKind)
       return nil
    end
 
@@ -52,7 +52,7 @@ function handler_helper.get_node_info(document_manager: DocumentManager, params:
    logger:debug("Looking up node info at position: %s", pos)
    local node_info = doc:tree_sitter_token(pos.line, pos.character)
    if node_info == nil then
-      logger:warning("Unable to retrieve node info from tree-sitter parser")
+      logger:info("Unable to retrieve node info from tree-sitter parser")
       return nil
    end
    logger:debug("Found node info: %s", node_info)

--- a/src/teal_language_server/handlers/language_features.tl
+++ b/src/teal_language_server/handlers/language_features.tl
@@ -82,7 +82,7 @@ function LanguageFeatureHandlers:_on_completion(params: lsp.Method.Params, id: i
    local type_info = doc:type_information_for_tokens(tks, pos.line, pos.character)
 
    if not type_info then
-      logger:warning("Also failed to find type type_info based on token")
+      logger:info("Also failed to find type type_info based on token")
    end
 
    if type_info then
@@ -146,7 +146,7 @@ function LanguageFeatureHandlers:_on_completion(params: lsp.Method.Params, id: i
             end
          end
       else
-         logger:warning("Unable to get fields for ref type")
+         logger:info("Unable to get fields for ref type")
       end
    end
 


### PR DESCRIPTION
Many of these get hit frequently in situations where things don't resolve. Just clearing them up so logs look a little cleaner if people submit bug reports and their editors pull in logs from stderr.